### PR TITLE
TIP-4.1 CallbackParams[]

### DIFF
--- a/src/standard/TIP-4/1.md
+++ b/src/standard/TIP-4/1.md
@@ -147,8 +147,9 @@ pragma ton-solidity >= 0.58.0;
 interface TIP4_1NFT {
 
     struct CallbackParams {
-        uint128 value;      // ever value will be sent to address
-        TvmCell payload;    // custom payload will be proxied to address
+        address receiver;   // Callback receiver address
+        uint128 value;      // Ever value will be sent to receiver address
+        TvmCell payload;    // Custom payload will be proxied to receiver address
     }
 
     /// @notice The event emits when NFT is created
@@ -188,7 +189,7 @@ interface TIP4_1NFT {
     /// @param newOwner New owner of NFT
     /// @param sendGasTo Address to send remaining gas
     /// @param callbacks Callbacks array to send by addresses. It can be empty
-    function changeOwner(address newOwner, address sendGasTo, mapping(address => CallbackParams) callbacks) external;
+    function changeOwner(address newOwner, address sendGasTo, CallbackParams[] callbacks) external;
 
     /// @notice Change NFT manager
     /// @dev Invoked from manager address only
@@ -196,7 +197,7 @@ interface TIP4_1NFT {
     /// @param newManager New manager of NFT
     /// @param sendGasTo Address to send remaining gas
     /// @param callbacks Callbacks array to send by addresses. It can be empty
-    function changeManager(address newManager, address sendGasTo, mapping(address => CallbackParams) callbacks) external;
+    function changeManager(address newManager, address sendGasTo, CallbackParams[] callbacks) external;
 
     /// @notice Change NFT owner and manager
     /// @dev Invoked from manager address only
@@ -205,10 +206,10 @@ interface TIP4_1NFT {
     /// @param to New NFT owner and manager
     /// @param sendGasTo Address to send remaining gas
     /// @param callbacks Callbacks array to send by addresses. It can be empty
-    function transfer(address to, address sendGasTo, mapping(address => CallbackParams) callbacks) external;
+    function transfer(address to, address sendGasTo, CallbackParams[] callbacks) external;
 }
 ```
-**NOTE** The [TIP-6.1](./../TIP-6/1.md) identifier for this interface is `0x78084F7E`.
+**NOTE** The [TIP-6.1](./../TIP-6/1.md) identifier for this interface is `0x5F0D787C`.
 
 ### TIP4_1NFT.getInfo()
 ```solidity
@@ -221,7 +222,7 @@ function getInfo() public view responsible returns(uint256 id, address owner, ad
 
 ### TIP4_1NFT.changeOwner()
 ```solidity
-function changeOwner(address newOwner, address sendGasTo, mapping(address => CallbackParams) callbacks) external;
+function changeOwner(address newOwner, address sendGasTo, CallbackParams[] callbacks) external;
 ```
 * `newOwner` (`address`) -  New owner of NFT
 * `sendGasTo` (`address`) - Address to send remaining gas. It sent to all callback addresses, too
@@ -238,7 +239,7 @@ Change NFT owner. You must emit `OwnerChanged` event when NFT owner changed. The
 
 ### TIP4_1NFT.changeManager()
 ```solidity
-function changeManager(address newManager, address sendGasTo, mapping(address => CallbackParams) callbacks) external;
+function changeManager(address newManager, address sendGasTo, CallbackParams[] callbacks) external;
 ```
 * `newManager` (`address`) - New manager of NFT
 * `sendGasTo` (`address`) - Address to send remaining gas. It sent to all callback addresses too
@@ -255,7 +256,7 @@ Change NFT manager. You must emit `ManagerChanged` event when NFT owner changed.
 
 ### TIP4_1NFT.transfer()
 ```solidity
-function transfer(address to, address sendGasTo, mapping(address => CallbackParams) callbacks) external;
+function transfer(address to, address sendGasTo, CallbackParams[] callbacks) external;
 ```
 * `to` (`address`) - New NFT owner and manager
 * `sendGasTo` (`address`) - Address to send remaining gas. It sent to all callback addresses too


### PR DESCRIPTION
# Explanation copy from [issue comment](https://github.com/everscale-org/docs/pull/156#issuecomment-1141077997)

**Now**
```solidity
struct CallbackParams {
    uint128 value;      // ever value will be sent to address
    TvmCell payload;    // custom payload will be proxied to address
}
```

```solidity
mapping(address => CallbackParams) callbacks
```

**Must be**
```solidity
struct CallbackParams {
    address receiver;   // Callback receiver address
    uint128 value;      // Ever value will be sent to receiver address
    TvmCell payload;    // Custom payload will be proxied to receiver address
}
```

```
CallbackParams[] callbacks
```

### Why `array` instead `map`
It's **cheaper to loop over an array than it is over a map**. It is silly to pass a callback to the map that you will not call - you need loop over all the callbacks

**Now**
```solidity
for ((address destination, CallbackParams parameters) : callbacks) {
    INFTTransfer(destination).onNftTransfer {
        value: parameters.value,
        flag: MessageFlags.SENDER_PAYS_FEES,
        bounce: false
    }(_id, oldOwner, newOwner, oldManager, newOwner, _collection, sendGasTo, parameters.payload);
}
```

**Must be**
```solidity
for (uint i; i < callbacks.length; ++i) {
	CallbackParams callback = callbacks[i];
    INFTTransfer(callback.receiver).onNftTransfer {
        value: callback.value,
        flag: MessageFlags.SENDER_PAYS_FEES,
        bounce: false
    }(_id, oldOwner, newOwner, oldManager, newOwner, _collection, sendGasTo, callback.payload);
}
```