### PR TITLE
Fix types and params in TIP4.4 Storage

### DIFF
--- a/src/standard/TIP-4/4.md
+++ b/src/standard/TIP-4/4.md
@@ -90,17 +90,18 @@ interface TIP4_4Storage {
         address nft,
         address collection,
         string mimeType,
-        mapping(uint8 => bytes) content
+        mapping(uint32 => bytes) content,
+        string contentEncoding
     );
 }
 ```
-**NOTE** The [TIP-6.1](../TIP-6/1.md) identifier for this interface is `0x4855B0B8`
+**NOTE** The [TIP-6.1](../TIP-6/1.md) identifier for this interface is `0x204D6296`
 
 ### TIP4_4Storage.fill()
 ```solidity
-function fill(uint8 id, bytes chunk, address gasReceiver) external;
+function fill(uint32 id, bytes chunk, address gasReceiver) external;
 ```
-* `id` (`uint32`) - chunk number. From `0` to `2 147 483 647`
+* `id` (`uint32`) - chunk number. From `0` to `4 294 967 295`
 * `bytes` (`chunk`) - data. Max size of data is limited by external message payload size. Maximum size external message payload size is `16KB` at 2022-03-18.
 * `gasReceiver` (`address`) - address of contract that receive all remaining contract balance then last chunk filled.
 
@@ -118,8 +119,8 @@ function getInfo() external view responsible returns (
 * `nft` (`address`) - token contract address
 * `collection` (`address`) - collection token contract address
 * `mimeType` (`string`) - [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) are defined and standardized in IETF's [RFC 6838](https://datatracker.ietf.org/doc/html/rfc6838)
- `content` (`mapping(uint32 => bytes)`) - byte content. Maximum content size is `2 147 483 647 chunks * chunk size`. Max size of data is limited by external message payload size. Maximum size external message payload size is `16KB` at 2022-03-18 Maximum content size is `2 147 483 647 * 16KB = 34TB` at 2022-03-18.
- `contentEncoding` (`string`) - Was it compressed by any algorithm. If it was compressed with [zstd](https://github.com/tonlabs/ever-sdk/blob/master/docs/reference/types-and-methods/mod_utils.md#compress_zstd) contentEncoding need to be `zstd`, all other need to be like [http content encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding)
+* `content` (`mapping(uint32 => bytes)`) - byte content. Maximum content size is `4 294 967 295 chunks * chunk size`. Max size of data is limited by external message payload size. Maximum size external message payload size is `16KB` at 2022-03-18 Maximum content size is `4 294 967 295 * 16KB ≈ 69TB` at 2022-03-18.
+* `contentEncoding` (`string`) - Was it compressed by any algorithm. If it was compressed with [zstd](https://github.com/tonlabs/ever-sdk/blob/master/docs/reference/types-and-methods/mod_utils.md#compress_zstd) contentEncoding need to be `zstd`, all other need to be like [http content encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding)
 
 ## Visualization
 ### Legend


### PR DESCRIPTION
1) Fix misunderstanding that in some places `chunks` has `uint8` type and in others `uint32` -> now using only `uint32`
2) Add `contentEncoding` in `getInfo` interface in order to match the description of this method
3) Update TIP6 identifier for Storage interface to fit previous changes
