### PR TITLE
feat: Add TIP 4.5

### DIFF
--- a/src/standard/TIP-4/5.md
+++ b/src/standard/TIP-4/5.md
@@ -1,0 +1,113 @@
+---
+title: 4.5. Can't Be Evil licensing
+sidebar_position: 4
+slug: /standard/TIP-4.5
+---
+
+# Non-Fungible Token Can't Be Evil Licensing (TIP-4.5)
+Requires: [TIP-4.1](1.md)
+Requires: [TIP-6.1](./../TIP-6/1.md)
+
+## Abstract
+The standard adds the support of [Can't Be Evil NFT licenses](https://github.com/a16z/a16z-contracts) [introduced](https://a16zcrypto.com/introducing-nft-licenses/) by [Andreessen.Horowitz](https://a16z.com).
+
+## Motivation
+The purpose of this standard is to provide an on-chain representation of the `CantBeEvil` license.
+
+The `CantBeEvil` license is made available as a contract that can be inherited by any other contract.
+
+There are six variants of the `CantBeEvil` license:
+
+* [CC0 (“CBE-CC0”)](https://arweave.net/_D9kN1WrNWbCq55BSAGRbTB4bS3v8QAPTYmBThSbX3A/0) – All copyrights are waived under the terms of CC0 1.0 Universal developed by Creative Commons.
+* [Exclusive Commercial Rights with No Creator Retention (“CBE-ECR”)](https://arweave.net/_D9kN1WrNWbCq55BSAGRbTB4bS3v8QAPTYmBThSbX3A/1) – Full exclusive commercial rights granted, with no hate speech termination. Creator does not retain any exploitation rights.
+* [Non-Exclusive Commercial Rights (“CBE-NECR”)](https://arweave.net/_D9kN1WrNWbCq55BSAGRbTB4bS3v8QAPTYmBThSbX3A/2) – Full non-exclusive commercial rights granted, with no hate speech termination. Creator retains exploitation rights.
+* [Non-Exclusive Commercial Rights with Creator Retention & Hate Speech Termination (“CBE-NECR-HS”)](https://arweave.net/_D9kN1WrNWbCq55BSAGRbTB4bS3v8QAPTYmBThSbX3A/3) – Full non-exclusive commercial rights granted, with hate speech termination. Creator retains exploitation rights.
+* [Personal License (“CBE-PR”)](https://arweave.net/_D9kN1WrNWbCq55BSAGRbTB4bS3v8QAPTYmBThSbX3A/4) – Personal rights granted, without hate speech termination.
+* [Personal License with Hate Speech Termination (“CBE-PR-HS”)](https://arweave.net/_D9kN1WrNWbCq55BSAGRbTB4bS3v8QAPTYmBThSbX3A/5) – Personal rights granted, with hate speech termination.
+
+The text of the Licenses is made freely available to the public under the terms of CC0 1.0 Universal. You can also find the full licenses and cover letter in this repo [here](https://github.com/a16z/a16z-contracts/blob/master/licenses).
+
+## Specification
+The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+### Contracts and interfaces
+* `Collection` - [TIP4.1](1.md) contract that mints tokens;
+* `NFT` - [TIP4.1](1.md) contract that store token information;
+* `CantBeEvil` - contract that is meant to be inherited by NFT contracts and any contract that wishes to expose the `getLicenseURI` and `getLicenseName` methods.
+
+### CantBeEvil
+* Every [TIP-4.1](1.md) `NFT` contract MAY implement instance of `CantBeEvil` contract. `NFT` tokens within the same collection MAY have different license versions unless the version is specifically set in the `Collection` contract;
+* Every [TIP-4.1](1.md) `Collection` contract MAY implement instance of `CantBeEvil` contract. In such case, the derived [TIP-4.1](1.md) `NFT` contract MUST inherit the same license from the collection.
+
+#### `ICantBeEvil.sol`
+```solidity
+pragma ever-solidity >= 0.61.2;
+
+interface ICantBeEvil {
+    function getLicenseURI() external view responsible returns (string);
+    function getLicenseName() external view responsible returns (string);
+}
+```
+
+#### `CantBeEvil.sol`
+```solidity
+pragma ever-solidity >= 0.61.2;
+
+import "./ICantBeEvil.sol";
+
+enum LicenseVersion {
+    CBE_CC0,
+    CBE_ECR,
+    CBE_NECR,
+    CBE_NECR_HS,
+    CBE_PR,
+    CBE_PR_HS
+}
+
+contract CantBeEvil is ICantBeEvil {
+    string internal constant _BASE_LICENSE_URI = "ar://_D9kN1WrNWbCq55BSAGRbTB4bS3v8QAPTYmBThSbX3A/";
+    LicenseVersion public licenseVersion; // return string
+	
+    constructor(LicenseVersion _licenseVersion) public {
+        licenseVersion = _licenseVersion;
+    }
+
+    function getLicenseURI() public view responsible override returns (string) {
+        return format("{}{}", _BASE_LICENSE_URI, uint(licenseVersion));
+    }
+
+    function getLicenseName() public view responsible override returns (string) {
+        return _getLicenseVersionKeyByValue(licenseVersion);
+    }
+
+    function _getLicenseVersionKeyByValue(LicenseVersion _licenseVersion) internal pure returns (string) {
+        require(uint8(_licenseVersion) <= 6);
+        if (LicenseVersion.CBE_CC0 == _licenseVersion) return "CBE_CC0";
+        if (LicenseVersion.CBE_ECR == _licenseVersion) return "CBE_ECR";
+        if (LicenseVersion.CBE_NECR == _licenseVersion) return "CBE_NECR";
+        if (LicenseVersion.CBE_NECR_HS == _licenseVersion) return "CBE_NECR_HS";
+        if (LicenseVersion.CBE_PR == _licenseVersion) return "CBE_PR";
+        else return "CBE_PR_HS";
+    }
+}
+```
+
+**NOTE** The [TIP-6.1](../TIP-6/1.md) identifier for this interface is `0x1E4848D4`.
+
+## Usage
+
+Pass the desired version into the CantBeEvil constructor, as shown:
+
+```solidity
+import {LicenseVersion, CantBeEvil} from "./CantBeEvil.sol";
+
+contract MyContract is CantBeEvil(LicenseVersion.CC0) {
+    ...
+}
+```
+
+You can now call `MyContract.getLicenseURI()`, which will return an Arweave gateway link to the license text file.
+
+```solidity
+MyContract.getLicenseURI() // => "https://arweave.net/d2k7..."
+```

--- a/src/standard/TIP-4/core-description.md
+++ b/src/standard/TIP-4/core-description.md
@@ -36,12 +36,16 @@ On-chain Indexes solves easy and fast searching any data in blockchain. [TIP-4.3
 ##  (Status:Draft) [On-chain storage (TIP-4.4)](./../TIP-4/4.md)
 Using the Storage contract, you can store NFT-related bytes in blockchain. [TIP-4.4](./../TIP-4/4.md) is optional, but can be used for fault tolerance. If off-chain services are unavailable, the user will view NFT-related bytes, because it is stored on-chain.
 
+##  (Status:Draft) [Don't Be Evil NFT licensing (TIP-4.5)](./../TIP-4/5.md)
+The standard adds the support of [Can't Be Evil NFT licenses](https://github.com/a16z/a16z-contracts) [introduced](https://a16zcrypto.com/introducing-nft-licenses/) by [Andreessen.Horowitz](https://a16z.com). [TIP-4.5](./../TIP-4/5.md) is optional, but can be used for clarifying the legal basis of NFT usage by the owner.
+
 
 ## Authors
 | Author                                          | Command                                  |
 |-------------------------------------------------|------------------------------------------|
 | [Aleksand Aleksev](mailto:rualekseev@gmail.com) | [grandbazar.io](https://grandbazar.io)   |
 | Aleksandr Khramtsov                             | [broxus](https://broxus.com/)            |
+| Vladislav Ponomarev                             | [broxus](https://broxus.com/)            |
 | [Andrey Nedobylskiy](https://t.me/nedobylskiy)  | [svoi.dev](https://svoi.dev)             |
 | [Anton Platonov](https://t.me/SuperArmor)       | community member                         |
 | [Nikita](https://t.me/kokkekpek)                | [numiz.org](https://numiz.org/)          |


### PR DESCRIPTION
The standard adds the support of [Can't Be Evil NFT licenses](https://github.com/a16z/a16z-contracts) [introduced](https://a16zcrypto.com/introducing-nft-licenses/) by [Andreessen.Horowitz](https://a16z.com).