### PR TITLE
TIP 4.2 Add "basic collection" metadata standart

### DIFF
--- a/src/standard/TIP-4/2.md
+++ b/src/standard/TIP-4/2.md
@@ -324,6 +324,63 @@ Sphere is described by coordinates of central point and radius.
 * Numbers are stored as strings to ensure maximum compatibility;
 * Numbers must not use scientific notation.
 
+## JSON metadata type: "Basic Collection"
+
+The `Basic Collection` use for links to files stores in web. JSON fields contain information about nft collection, files, preview info, tags etc.
+
+The `Basic Collection` describes fields that must be in JSON
+
+| Field name           | type   | Value                                                                                               | Description                     |
+|----------------------|--------|-----------------------------------------------------------------------------------------------------|---------------------------------|
+| **type**             | string || "Basic Collection"                                                                                 | Constant name for this type     |
+| **name**             | string || Collection name                                                                                    |                                 |
+| **description**      | string || Collection description                                                                             |                                 |
+| **tags**             | array  || Array of strings                                                                                   | Array of tags like art, game, 3d|
+| **preview**          | object || Object preview                                                                                     |                                 |
+| **preview.source**   | string || Link to object. Contains protocol and data source. Delimiter is **:**                              |                                 |
+| **preview.mimetype** | string || [Mime type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of object |                                 |
+| **banner**           | object || Object banner                                                                                      |                                 |
+| **banner.source**    | string || Link to object. Contains protocol and data source. Delimiter is **:**                              |                                 |
+| **banner.mimetype**  | string || [Mime type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of object |                                 |
+| **files**            | array  || Array of objects.                                                                                  |                                 |
+| **file.source**      | string || Link to object. Contains protocol and data source. Delimiter is **:**                              |                                 |
+| **file.mimetype**    | string || [Mime type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of object |                                 |
+| **external_url**     | string || URL to website                                                                                     |                                 |
+| **links**            | array  || Array of strings                                                                                   |                                 | 
+
+### Example
+
+```JSON
+{
+    "type": "Basic Collection",
+    "name": "Test collection",
+    "description": "Test collection description!",
+	"tags": [
+		"art", 
+		"3d",
+		"game"
+	],
+    "preview": {
+        "source": "https://everscale.network/images/Backgrounds/Main/main-hero.png",
+        "mimetype": "image/png"
+    },
+	"banner": {
+        "source": "https://everscale.network/images/Backgrounds/Main/main-hero.png",
+        "mimetype": "image/png"
+    },
+    "files": [
+        {
+            "source": "https://everscale.network/images/Backgrounds/Main/main-hero.png",
+            "mimetype": "image/png"
+        }
+    ],
+    "external_url": "https://everscale.network",
+	"links": ["https://twitter.com/Everscale_net", "https://t.me/everscale"]
+}
+```
+
+You can extend `Basic Collection` type for your custom fields.
+
 ## How to add the new JSON metadata type?
 
 For added new metadata type of [TIP-4.2](2.md)


### PR DESCRIPTION
## Motivation

Not enough TIP 4.2 **Basic NFT** metadata standard for collection describe. 
We want to see tags, banner img, social links inside collection metadata.

## Backwards compatibility

It's not affected for all collections that already deployed.

## Specification

I ask you to add "Basic Collection" metadata standard, that:

- Include all fields from Basic NFT metadata standard
- Add array of tags
- Add banner image
- Add array of links


