### PR TITLE
Update TIP 4.5

### DIFF
--- a/src/standard/TIP-4/5.md
+++ b/src/standard/TIP-4/5.md
@@ -1,113 +1,48 @@
 ---
-title: 4.5. Can't Be Evil licensing
+title: 4.5. NFT Licensing
 sidebar_position: 4
 slug: /standard/TIP-4.5
 ---
 
-# Non-Fungible Token Can't Be Evil Licensing (TIP-4.5)
+# Non-Fungible Licensing (TIP-4.5)
 Requires: [TIP-4.1](1.md)
 Requires: [TIP-6.1](./../TIP-6/1.md)
 
 ## Abstract
-The standard adds the support of [Can't Be Evil NFT licenses](https://github.com/a16z/a16z-contracts) [introduced](https://a16zcrypto.com/introducing-nft-licenses/) by [Andreessen.Horowitz](https://a16z.com).
+
+The NFT License Standart is a standard set of functions for retrieving license information. This interface allows external callers to access the license URI and the license name associated with a specific entity. The preferred but not mandatory method of storing license links is using IPFS. A collection of NFT licenses can be obtained via a [link](https://github.com/a16z/a16z-contracts). 
 
 ## Motivation
-The purpose of this standard is to provide an on-chain representation of the `CantBeEvil` license.
 
-The `CantBeEvil` license is made available as a contract that can be inherited by any other contract.
-
-There are six variants of the `CantBeEvil` license:
-
-* [CC0 (“CBE-CC0”)](https://arweave.net/_D9kN1WrNWbCq55BSAGRbTB4bS3v8QAPTYmBThSbX3A/0) – All copyrights are waived under the terms of CC0 1.0 Universal developed by Creative Commons.
-* [Exclusive Commercial Rights with No Creator Retention (“CBE-ECR”)](https://arweave.net/_D9kN1WrNWbCq55BSAGRbTB4bS3v8QAPTYmBThSbX3A/1) – Full exclusive commercial rights granted, with no hate speech termination. Creator does not retain any exploitation rights.
-* [Non-Exclusive Commercial Rights (“CBE-NECR”)](https://arweave.net/_D9kN1WrNWbCq55BSAGRbTB4bS3v8QAPTYmBThSbX3A/2) – Full non-exclusive commercial rights granted, with no hate speech termination. Creator retains exploitation rights.
-* [Non-Exclusive Commercial Rights with Creator Retention & Hate Speech Termination (“CBE-NECR-HS”)](https://arweave.net/_D9kN1WrNWbCq55BSAGRbTB4bS3v8QAPTYmBThSbX3A/3) – Full non-exclusive commercial rights granted, with hate speech termination. Creator retains exploitation rights.
-* [Personal License (“CBE-PR”)](https://arweave.net/_D9kN1WrNWbCq55BSAGRbTB4bS3v8QAPTYmBThSbX3A/4) – Personal rights granted, without hate speech termination.
-* [Personal License with Hate Speech Termination (“CBE-PR-HS”)](https://arweave.net/_D9kN1WrNWbCq55BSAGRbTB4bS3v8QAPTYmBThSbX3A/5) – Personal rights granted, with hate speech termination.
-
-The text of the Licenses is made freely available to the public under the terms of CC0 1.0 Universal. You can also find the full licenses and cover letter in this repo [here](https://github.com/a16z/a16z-contracts/blob/master/licenses).
+This standard was developed based on the previous version of the ["CantBeEvil"](https://github.com/everscale-org/docs/blob/6198a3be3428841b47d7072d87b10854aca6b879/src/standard/TIP-4/5.md) standard. The new "NFT Licensing" standard offers you more freedom and flexibility in using licenses for your NFT tokens, allowing you to choose any license that reflects your vision and protects your rights, provided that a link to it is provided.
 
 ## Specification
+
 The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).
 
-### Contracts and interfaces
-* `Collection` - [TIP4.1](1.md) contract that mints tokens;
-* `NFT` - [TIP4.1](1.md) contract that store token information;
-* `CantBeEvil` - contract that is meant to be inherited by NFT contracts and any contract that wishes to expose the `getLicenseURI` and `getLicenseName` methods.
 
-### CantBeEvil
-* Every [TIP-4.1](1.md) `NFT` contract MAY implement instance of `CantBeEvil` contract. `NFT` tokens within the same collection MAY have different license versions unless the version is specifically set in the `Collection` contract;
-* Every [TIP-4.1](1.md) `Collection` contract MAY implement instance of `CantBeEvil` contract. In such case, the derived [TIP-4.1](1.md) `NFT` contract MUST inherit the same license from the collection.
-
-#### `ICantBeEvil.sol`
+### TIP4_5
 ```solidity
 pragma ever-solidity >= 0.61.2;
 
-interface ICantBeEvil {
+interface ITIP4_5 {
     function getLicenseURI() external view responsible returns (string);
     function getLicenseName() external view responsible returns (string);
 }
 ```
 
-#### `CantBeEvil.sol`
+**NOTE** The [TIP-6.1](../TIP-6/1.md) identifier for this interface is `0x8A1EB91` (with responsible) and `0x1E4848D4` (without responsible).
+
+### TIP4_5.getLicenseURI()
 ```solidity
-pragma ever-solidity >= 0.61.2;
-
-import "./ICantBeEvil.sol";
-
-enum LicenseVersion {
-    CBE_CC0,
-    CBE_ECR,
-    CBE_NECR,
-    CBE_NECR_HS,
-    CBE_PR,
-    CBE_PR_HS
-}
-
-contract CantBeEvil is ICantBeEvil {
-    string internal constant _BASE_LICENSE_URI = "ar://_D9kN1WrNWbCq55BSAGRbTB4bS3v8QAPTYmBThSbX3A/";
-    LicenseVersion public licenseVersion; // return string
-	
-    constructor(LicenseVersion _licenseVersion) public {
-        licenseVersion = _licenseVersion;
-    }
-
-    function getLicenseURI() public view responsible override returns (string) {
-        return format("{}{}", _BASE_LICENSE_URI, uint(licenseVersion));
-    }
-
-    function getLicenseName() public view responsible override returns (string) {
-        return _getLicenseVersionKeyByValue(licenseVersion);
-    }
-
-    function _getLicenseVersionKeyByValue(LicenseVersion _licenseVersion) internal pure returns (string) {
-        require(uint8(_licenseVersion) <= 6);
-        if (LicenseVersion.CBE_CC0 == _licenseVersion) return "CBE_CC0";
-        if (LicenseVersion.CBE_ECR == _licenseVersion) return "CBE_ECR";
-        if (LicenseVersion.CBE_NECR == _licenseVersion) return "CBE_NECR";
-        if (LicenseVersion.CBE_NECR_HS == _licenseVersion) return "CBE_NECR_HS";
-        if (LicenseVersion.CBE_PR == _licenseVersion) return "CBE_PR";
-        else return "CBE_PR_HS";
-    }
-}
+function getLicenseURI() external view responsible returns (string);
 ```
 
-**NOTE** The [TIP-6.1](../TIP-6/1.md) identifier for this interface is `0x1E4848D4`.
+Returns the license URI. The license URI represents the location or identifier that can be used to access the full details of the license, such as terms and conditions, permissions, and restrictions.
 
-## Usage
-
-Pass the desired version into the CantBeEvil constructor, as shown:
-
+### TIP4_5.getLicenseName()
 ```solidity
-import {LicenseVersion, CantBeEvil} from "./CantBeEvil.sol";
-
-contract MyContract is CantBeEvil(LicenseVersion.CC0) {
-    ...
-}
+function getLicenseName() external view responsible returns (string);
 ```
 
-You can now call `MyContract.getLicenseURI()`, which will return an Arweave gateway link to the license text file.
-
-```solidity
-MyContract.getLicenseURI() // => "https://arweave.net/d2k7..."
-```
+Returns the name or title of the license. The license name provides a concise and descriptive representation of the license type or category.


### PR DESCRIPTION
Add license localization.
The implementation of the standard methods has been removed.
Removed the binding of storing licenses in a specific repository.